### PR TITLE
Fix timezone issue with DateTime in Schedule payload test

### DIFF
--- a/src/test/java/com/urbanairship/api/schedule/SchedulePayloadSerializerTest.java
+++ b/src/test/java/com/urbanairship/api/schedule/SchedulePayloadSerializerTest.java
@@ -12,7 +12,6 @@ import org.codehaus.jackson.map.ObjectMapper;
 import org.joda.time.DateTime;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class SchedulePayloadSerializerTest {
@@ -29,13 +28,13 @@ public class SchedulePayloadSerializerTest {
                 .build();
         SchedulePayload schedulePayload = SchedulePayload.newBuilder()
                 .setSchedule(Schedule.newBuilder().setScheduledTimestamp(
-                        new DateTime("2013-05-05T00:00:01")).build())
+                        new DateTime("2013-05-05T00:00:01Z")).build())
                 .setPushPayload(pushPayload)
                 .build();
 
         String json = MAPPER.writeValueAsString(schedulePayload);
 
-        String properJson = "{\"schedule\":{\"scheduled_time\":\"2013-05-05T07:00:01\"},\"push\":{\"audience\":{\"tag\":\"tag\"},\"device_types\":[\"ios\"],\"notification\":{\"alert\":\"alert\"}}}";
+        String properJson = "{\"schedule\":{\"scheduled_time\":\"2013-05-05T00:00:01\"},\"push\":{\"audience\":{\"tag\":\"tag\"},\"device_types\":[\"ios\"],\"notification\":{\"alert\":\"alert\"}}}";
 
         assertTrue(json.equals(properJson));
     }


### PR DESCRIPTION
Using the 'Z' at the end of the DateTime string forces the parser
to treat the time as UTC. Before, it was dependent on the timezone
set on the machine running the tests. I've added the 'Z' and changed
the expected date as it will stay UTC throughout now.
