### PR TITLE
Use param, not params for mpns toast json

### DIFF
--- a/src/main/java/com/urbanairship/api/push/parse/notification/mpns/MPNSToastSerializer.java
+++ b/src/main/java/com/urbanairship/api/push/parse/notification/mpns/MPNSToastSerializer.java
@@ -23,7 +23,7 @@ public class MPNSToastSerializer extends JsonSerializer<MPNSToastData> {
             jgen.writeStringField("text2", toast.getText2().get());
         }
         if (toast.getParam().isPresent()) {
-            jgen.writeStringField("params", toast.getParam().get());
+            jgen.writeStringField("param", toast.getParam().get());
         }
 
         jgen.writeEndObject();


### PR DESCRIPTION
I am using 0.2.2 and it uses "params" instead of "param" when creating json for payload. This is the wrong syntax.
