### PR TITLE
Fixes a bug in the PushExpiry serialization.

### DIFF
--- a/src/main/java/com/urbanairship/api/push/parse/PushExpirySerializer.java
+++ b/src/main/java/com/urbanairship/api/push/parse/PushExpirySerializer.java
@@ -19,15 +19,11 @@ public class PushExpirySerializer extends JsonSerializer<PushExpiry> {
 
     @Override
     public void serialize(PushExpiry payload, JsonGenerator jgen, SerializerProvider provider) throws IOException {
-        jgen.writeStartObject();
-
         if (payload.getExpiryTimeStamp().isPresent()) {
-            jgen.writeStringField("expiryTimestamp", DateFormats.DATE_FORMATTER.print(payload.getExpiryTimeStamp().get()));
+            jgen.writeString(DateFormats.DATE_FORMATTER.print(payload.getExpiryTimeStamp().get()));
         }
         if (payload.getExpirySeconds().isPresent()) {
-            jgen.writeNumberField("expirySeconds", payload.getExpirySeconds().get());
+            jgen.writeNumber(payload.getExpirySeconds().get());
         }
-
-        jgen.writeEndObject();
     }
 }

--- a/src/test/java/com/urbanairship/api/push/parse/PushOptionsTest.java
+++ b/src/test/java/com/urbanairship/api/push/parse/PushOptionsTest.java
@@ -69,10 +69,7 @@ public class PushOptionsTest {
 
     @Test
     public void testParseExpiry() throws Exception {
-        String json
-                = "{"
-                + "\"expirySeconds\":600" /* expire in 10 minutes */
-                + "}";
+        String json = "600"; /* expire in 10 minutes */
         PushOptions options = PushOptions.newBuilder().setExpiry(PushExpiry.newBuilder().setExpirySeconds(600L).build()).build();
         assertTrue(options.getExpiry().isPresent());
         PushExpiry expiry = options.getExpiry().get();
@@ -124,7 +121,7 @@ public class PushOptionsTest {
 
         String properJson
                 = "{"
-                + "\"expiry\":{\"expirySeconds\":3600}"
+                + "\"expiry\":3600"
                 + "}";
 
         assertEquals(properJson, json);
@@ -140,7 +137,7 @@ public class PushOptionsTest {
 
         String properJson
                 = "{"
-                + "\"expiry\":{\"expiryTimestamp\":\"2014-07-08T12:00:00\"}"
+                + "\"expiry\":\"2014-07-08T12:00:00\""
                 + "}";
 
         assertEquals(properJson, json);

--- a/src/test/java/com/urbanairship/api/push/parse/richpush/RichPushDevicePayloadSerializerTest.java
+++ b/src/test/java/com/urbanairship/api/push/parse/richpush/RichPushDevicePayloadSerializerTest.java
@@ -29,7 +29,7 @@ public class RichPushDevicePayloadSerializerTest {
                 + "\"body\":\"B\","
                 + "\"content_type\":\"text/html\","
                 + "\"content_encoding\":\"utf8\","
-                + "\"expiry\":{\"expirySeconds\":3600}"
+                + "\"expiry\":3600"
                 + "}";
         assertEquals(json, pushJson);
     }


### PR DESCRIPTION
The server does not understand the expiryTimestamp and expirySeconds fields, but just the expiry field.

The json now conforms to http://docs.urbanairship.com/api/ua.html#expiry.

However I would request that you double check that server code can handle expiry being either a string or a number (as the documentation states)
