### PR TITLE
Update docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -231,7 +231,7 @@ More complex logic is possible
 
 .. code-block:: java
 
-   Selector andSelector = Selectors.tags("puppies", "kittens");
+   Selector andSelector = Selectors.and(Selectors.tag("puppies"), Selectors.tag("kittens"));
    Selector notSelector = Selectors.not(Selectors.tag("fish"));
    Selector compound = Selectors.or(andSelector, notSelector);
 


### PR DESCRIPTION
Fixes a small error in the docs -- `Selectors.tags('tag1', 'tag2', ...)` is an implicit `or`, not `and`. See [DOCS-231](https://tofurkey.urbanairship.com/browse/DOCS-231).