### PR TITLE
Upgrade of Jersey and Guava libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <jersey.version>2.19</jersey.version>
         <jackson.version>1.9.8</jackson.version>
+        <guava.version>18.0</guava.version>
         <local.gpg.passphrase />
     </properties>
 
@@ -161,7 +162,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>12.0</version>
+            <version>${guava.version}</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <jersey.version>2.19</jersey.version>
+        <jersey.version>2.22.1</jersey.version>
         <jackson.version>1.9.8</jackson.version>
         <guava.version>18.0</guava.version>
         <local.gpg.passphrase />

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <jersey.version>1.9.1</jersey.version>
+        <jersey.version>2.19</jersey.version>
         <jackson.version>1.9.8</jackson.version>
         <local.gpg.passphrase />
     </properties>
@@ -153,14 +153,8 @@
         </dependency>
 
         <dependency>
-            <groupId>com.sun.jersey</groupId>
+            <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-server</artifactId>
-            <version>${jersey.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.sun.jersey</groupId>
-            <artifactId>jersey-core</artifactId>
             <version>${jersey.version}</version>
         </dependency>
 

--- a/src/main/java/com/urbanairship/api/reports/Base64ByteArray.java
+++ b/src/main/java/com/urbanairship/api/reports/Base64ByteArray.java
@@ -4,19 +4,23 @@
 
 package com.urbanairship.api.reports;
 
-import com.google.common.base.Preconditions;
-import com.sun.jersey.core.util.Base64;
-
 import java.util.Arrays;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.glassfish.jersey.internal.util.Base64;
+
+import com.google.common.base.Preconditions;
 
 public final class Base64ByteArray {
 
     public byte[] binary;
 
     public Base64ByteArray(String value) {
-        Preconditions.checkArgument(Base64.isBase64(value));
+            	
+    	Preconditions.checkArgument(checkForEncode(value));
 
-        this.binary = Base64.decode(value);
+        this.binary = Base64.decode(value.getBytes());
     }
 
     public byte[] getByteArray() {
@@ -32,6 +36,21 @@ public final class Base64ByteArray {
         return new String(binary);
     }
 
+    /**
+     * Internal implementation of check is required as Jersey 2.x no longer has method Base64.isBase64().
+     * As a transient dependency Apache Commons library is providing it's Base64 implementation with appropriate method for checks,
+     * but this library can produce false positives as it treats whitespaces as positives in evaluation.
+     * 
+     * @param string Value to be checked.
+     * @return Flag indicating if input string is Base64 encoded.
+     */
+    private boolean checkForEncode(String string) {
+        String pattern = "^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{4}|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)$";
+        Pattern r = Pattern.compile(pattern);
+        Matcher m = r.matcher(string);
+        return m.find();
+    }
+    
     // Does not use Guava::Objects, gives inconsistent results with byte array
     @Override
     public boolean equals(Object o) {


### PR DESCRIPTION
Upgrading Jersey and Guava libraries to latest versions.
Jersey to 2.22.1 and Guava to 18.0.

Upgrade would be simple POM change, if it wasn't for Jersey dropping some check methods related to Base64 encoding.

Main reason for the upgrade: conflicts in projects where I added UA client.