### PR TITLE
Remove Apache Commons Collections

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,10 @@
 
 -------------------------
+0.4.1 07MAR16
+-------------------------
+- Removed Apache Commons Collections 3.2.1 due to a security vulnerability https://commons.apache.org/proper/commons-collections/security-reports.html
+
+-------------------------
 0.4 04JUN15
 -------------------------
 - Push to named users

--- a/pom.xml
+++ b/pom.xml
@@ -135,12 +135,6 @@
         </dependency>
 
         <dependency>
-            <groupId>commons-collections</groupId>
-            <artifactId>commons-collections</artifactId>
-            <version>3.2.1</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-mapper-asl</artifactId>
             <version>${jackson.version}</version>

--- a/src/main/java/com/urbanairship/api/push/parse/audience/SelectorDeserializer.java
+++ b/src/main/java/com/urbanairship/api/push/parse/audience/SelectorDeserializer.java
@@ -14,123 +14,19 @@ import com.urbanairship.api.common.parse.StandardObjectDeserializer;
 import com.urbanairship.api.push.model.audience.Selector;
 import com.urbanairship.api.push.model.audience.SelectorType;
 import com.urbanairship.api.push.model.audience.Selectors;
-import org.apache.commons.collections.map.CaseInsensitiveMap;
 import org.codehaus.jackson.JsonParser;
 import org.codehaus.jackson.JsonToken;
 import org.codehaus.jackson.map.DeserializationContext;
 import org.codehaus.jackson.map.JsonDeserializer;
 
 import java.io.IOException;
+import java.util.Map;
+import java.util.TreeMap;
 
 public class SelectorDeserializer extends JsonDeserializer<Selector> {
 
-    private static final FieldParserRegistry<Selector, SelectorReader> FIELD_PARSERS
-        = new MapFieldParserRegistry<Selector, SelectorReader>(
-            new CaseInsensitiveMap(
-            ImmutableMap.<String, FieldParser<SelectorReader>>builder()
-            // Value selectors
-            .put("tag", new FieldParser<SelectorReader>() {
-                    @Override
-                    public void parse(SelectorReader reader, JsonParser parser, DeserializationContext context) throws IOException {
-                        reader.readValueSelector(SelectorType.TAG, parser, context);
-                    }
-                })
-            .put("alias", new FieldParser<SelectorReader>() {
-                    @Override
-                    public void parse(SelectorReader reader, JsonParser parser, DeserializationContext context) throws IOException {
-                        reader.readValueSelector(SelectorType.ALIAS, parser, context);
-                    }
-                })
-            .put("named_user", new FieldParser<SelectorReader>() {
-                @Override
-                public void parse(SelectorReader reader, JsonParser parser, DeserializationContext context) throws IOException {
-                    reader.readValueSelector(SelectorType.NAMED_USER, parser, context);
-                }
-            })
-            .put("segment", new FieldParser<SelectorReader>() {
-                    @Override
-                    public void parse(SelectorReader reader, JsonParser parser, DeserializationContext context) throws IOException {
-                        reader.readValueSelector(SelectorType.SEGMENT, parser, context);
-                    }
-                })
-
-            // Device ID value selectors
-            .put("device_token", new FieldParser<SelectorReader>() {
-                    @Override
-                    public void parse(SelectorReader reader, JsonParser parser, DeserializationContext context) throws IOException {
-                        reader.readValueSelector(SelectorType.DEVICE_TOKEN, parser, context);
-                    }
-                })
-            .put("device_pin", new FieldParser<SelectorReader>() {
-                    @Override
-                    public void parse(SelectorReader reader, JsonParser parser, DeserializationContext context) throws IOException {
-                        reader.readValueSelector(SelectorType.DEVICE_PIN, parser, context);
-                    }
-                })
-            .put("apid", new FieldParser<SelectorReader>() {
-                    @Override
-                    public void parse(SelectorReader reader, JsonParser parser, DeserializationContext context) throws IOException {
-                        reader.readValueSelector(SelectorType.APID, parser, context);
-                    }
-                })
-            .put("wns", new FieldParser<SelectorReader>() {
-                    @Override
-                    public void parse(SelectorReader reader, JsonParser parser, DeserializationContext context) throws IOException {
-                        reader.readValueSelector(SelectorType.WNS, parser, context);
-                    }
-                })
-            .put("mpns", new FieldParser<SelectorReader>() {
-                    @Override
-                    public void parse(SelectorReader reader, JsonParser parser, DeserializationContext context) throws IOException {
-                        reader.readValueSelector(SelectorType.MPNS, parser, context);
-                    }
-                })
-            .put("ios_channel", new FieldParser<SelectorReader>() {
-                @Override
-                public void parse(SelectorReader reader, JsonParser parser, DeserializationContext context) throws IOException {
-                    reader.readValueSelector(SelectorType.IOS_CHANNEL, parser, context);
-                }
-            })
-            .put("amazon_channel", new FieldParser<SelectorReader>() {
-                @Override
-                public void parse(SelectorReader reader, JsonParser parser, DeserializationContext context) throws IOException {
-                    reader.readValueSelector(SelectorType.AMAZON_CHANNEL, parser, context);
-                }
-            })
-            .put("android_channel", new FieldParser<SelectorReader>() {
-                @Override
-                public void parse(SelectorReader reader, JsonParser parser, DeserializationContext context) throws IOException {
-                    reader.readValueSelector(SelectorType.ANDROID_CHANNEL, parser, context);
-                }
-            })
-
-            // Compound selectors
-            .put("and", new FieldParser<SelectorReader>() {
-                    @Override
-                    public void parse(SelectorReader reader, JsonParser parser, DeserializationContext context) throws IOException {
-                        reader.readCompoundSelector(SelectorType.AND, parser, context);
-                    }
-                })
-            .put("or", new FieldParser<SelectorReader>() {
-                    @Override
-                    public void parse(SelectorReader reader, JsonParser parser, DeserializationContext context) throws IOException {
-                        reader.readCompoundSelector(SelectorType.OR, parser, context);
-                    }
-                })
-            .put("not", new FieldParser<SelectorReader>() {
-                    @Override
-                    public void parse(SelectorReader reader, JsonParser parser, DeserializationContext context) throws IOException {
-                        reader.readCompoundSelector(SelectorType.NOT, parser, context);
-                    }
-                })
-            .put("location", new FieldParser<SelectorReader>() {
-                    @Override
-                    public void parse(SelectorReader reader, JsonParser parser, DeserializationContext context) throws IOException {
-                        reader.readLocationSelector(parser);
-                    }
-                })
-            .build()),
-
+    private static final FieldParserRegistry<Selector, SelectorReader> FIELD_PARSERS = new MapFieldParserRegistry<Selector, SelectorReader>(
+            getRegistryMap(),
             // Default parser
             new FieldParser<SelectorReader>() {
                     @Override
@@ -138,7 +34,7 @@ public class SelectorDeserializer extends JsonDeserializer<Selector> {
                         reader.readExtraField(parser);
                     }
             }
-            );
+    );
 
     public static final SelectorDeserializer INSTANCE = new SelectorDeserializer();
 
@@ -184,5 +80,116 @@ public class SelectorDeserializer extends JsonDeserializer<Selector> {
         } else {
             throw new APIParsingException(String.format("Unknown atomic selector '%s'", value));
         }
+    }
+
+    private static Map<String, FieldParser<SelectorReader>> getRegistryMap() {
+        Map<String, FieldParser<SelectorReader>> registryMap = ImmutableMap.<String, FieldParser<SelectorReader>>builder()
+            // Value selectors
+            .put("tag", new FieldParser<SelectorReader>() {
+                @Override
+                public void parse(SelectorReader reader, JsonParser parser, DeserializationContext context) throws IOException {
+                    reader.readValueSelector(SelectorType.TAG, parser, context);
+                }
+            })
+            .put("alias", new FieldParser<SelectorReader>() {
+                @Override
+                public void parse(SelectorReader reader, JsonParser parser, DeserializationContext context) throws IOException {
+                    reader.readValueSelector(SelectorType.ALIAS, parser, context);
+                }
+            })
+            .put("named_user", new FieldParser<SelectorReader>() {
+                @Override
+                public void parse(SelectorReader reader, JsonParser parser, DeserializationContext context) throws IOException {
+                    reader.readValueSelector(SelectorType.NAMED_USER, parser, context);
+                }
+            })
+            .put("segment", new FieldParser<SelectorReader>() {
+                @Override
+                public void parse(SelectorReader reader, JsonParser parser, DeserializationContext context) throws IOException {
+                    reader.readValueSelector(SelectorType.SEGMENT, parser, context);
+                }
+            })
+
+                // Device ID value selectors
+            .put("device_token", new FieldParser<SelectorReader>() {
+                @Override
+                public void parse(SelectorReader reader, JsonParser parser, DeserializationContext context) throws IOException {
+                    reader.readValueSelector(SelectorType.DEVICE_TOKEN, parser, context);
+                }
+            })
+            .put("device_pin", new FieldParser<SelectorReader>() {
+                @Override
+                public void parse(SelectorReader reader, JsonParser parser, DeserializationContext context) throws IOException {
+                    reader.readValueSelector(SelectorType.DEVICE_PIN, parser, context);
+                }
+            })
+            .put("apid", new FieldParser<SelectorReader>() {
+                @Override
+                public void parse(SelectorReader reader, JsonParser parser, DeserializationContext context) throws IOException {
+                    reader.readValueSelector(SelectorType.APID, parser, context);
+                }
+            })
+            .put("wns", new FieldParser<SelectorReader>() {
+                @Override
+                public void parse(SelectorReader reader, JsonParser parser, DeserializationContext context) throws IOException {
+                    reader.readValueSelector(SelectorType.WNS, parser, context);
+                }
+            })
+            .put("mpns", new FieldParser<SelectorReader>() {
+                @Override
+                public void parse(SelectorReader reader, JsonParser parser, DeserializationContext context) throws IOException {
+                    reader.readValueSelector(SelectorType.MPNS, parser, context);
+                }
+            })
+            .put("ios_channel", new FieldParser<SelectorReader>() {
+                @Override
+                public void parse(SelectorReader reader, JsonParser parser, DeserializationContext context) throws IOException {
+                    reader.readValueSelector(SelectorType.IOS_CHANNEL, parser, context);
+                }
+            })
+            .put("amazon_channel", new FieldParser<SelectorReader>() {
+                @Override
+                public void parse(SelectorReader reader, JsonParser parser, DeserializationContext context) throws IOException {
+                    reader.readValueSelector(SelectorType.AMAZON_CHANNEL, parser, context);
+                }
+            })
+            .put("android_channel", new FieldParser<SelectorReader>() {
+                @Override
+                public void parse(SelectorReader reader, JsonParser parser, DeserializationContext context) throws IOException {
+                    reader.readValueSelector(SelectorType.ANDROID_CHANNEL, parser, context);
+                }
+            })
+
+                // Compound selectors
+            .put("and", new FieldParser<SelectorReader>() {
+                @Override
+                public void parse(SelectorReader reader, JsonParser parser, DeserializationContext context) throws IOException {
+                    reader.readCompoundSelector(SelectorType.AND, parser, context);
+                }
+            })
+            .put("or", new FieldParser<SelectorReader>() {
+                @Override
+                public void parse(SelectorReader reader, JsonParser parser, DeserializationContext context) throws IOException {
+                    reader.readCompoundSelector(SelectorType.OR, parser, context);
+                }
+            })
+            .put("not", new FieldParser<SelectorReader>() {
+                @Override
+                public void parse(SelectorReader reader, JsonParser parser, DeserializationContext context) throws IOException {
+                    reader.readCompoundSelector(SelectorType.NOT, parser, context);
+                }
+            })
+            .put("location", new FieldParser<SelectorReader>() {
+                @Override
+                public void parse(SelectorReader reader, JsonParser parser, DeserializationContext context) throws IOException {
+                    reader.readLocationSelector(parser);
+                }
+            })
+            .build();
+
+        TreeMap<String, FieldParser<SelectorReader>> caseInsensitiveRegistryMap = new TreeMap<String, FieldParser<SelectorReader>>(String.CASE_INSENSITIVE_ORDER);
+        caseInsensitiveRegistryMap.putAll(registryMap);
+
+        return caseInsensitiveRegistryMap;
     }
 }


### PR DESCRIPTION
There's a security vulnerability in commons collections 3.2.1 -- https://commons.apache.org/proper/commons-collections/security-reports.html. Commons collections is already an excessive dependency, so this will just remove it's usage altogether. 

This was first brought up in https://github.com/urbanairship/java-library/pull/46.