### PR TITLE
remove white space before string compare

### DIFF
--- a/src/main/java/com/urbanairship/api/client/RequestError.java
+++ b/src/main/java/com/urbanairship/api/client/RequestError.java
@@ -56,7 +56,9 @@ public final class RequestError {
      * @throws IOException if it fails reading the error
      */
     public static RequestError errorFromResponse(String body, String contentType) throws IOException {
-
+        // Remove white space
+        contentType = contentType.replace(' ', '');
+        
         // Text/html
         if (contentType.equalsIgnoreCase(CONTENT_TYPE_TEXT_HTML)) {
             return nonJSONError(body);


### PR DESCRIPTION
there is sometimes a space after the semi colon and before the version with vendor accept headers.  e.g. "application/vnd.urbanairship+json; version=3"

Removes any spaces from the received content type header before comparing to the constant values... content type headers sometimes have a space after the semi colon and sometimes don't.
