### PR TITLE
Fix template API call error parsing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -248,8 +248,7 @@
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock</artifactId>
-            <version>1.56</version>
-            <classifier>standalone</classifier>
+            <version>2.21.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/com/urbanairship/api/client/RequestError.java
+++ b/src/main/java/com/urbanairship/api/client/RequestError.java
@@ -5,9 +5,12 @@
 package com.urbanairship.api.client;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.google.common.base.Optional;
 import com.urbanairship.api.client.parse.RequestErrorObjectMapper;
+import com.urbanairship.api.common.parse.APIParsingException;
 
 import java.io.IOException;
 import java.util.Map;
@@ -69,8 +72,13 @@ public final class RequestError {
 
         // v3 JSON parsing
         else if (contentType.equalsIgnoreCase(UA_APPLICATION_JSON) || contentType.equalsIgnoreCase(UA_APPLICATION_JSON_V3)) {
-            ObjectMapper mapper = RequestErrorObjectMapper.getInstance();
-            return mapper.readValue(body, RequestError.class);
+            try {
+                ObjectMapper mapper = RequestErrorObjectMapper.getInstance();
+                return mapper.readValue(body, RequestError.class);
+            } catch (APIParsingException e) {
+                //Templates API returns a v3 Content-Type header, but does not conform to the standard error type
+                return nonV3JSONError(body);
+            }
         }
 
         // wut?
@@ -100,15 +108,68 @@ public final class RequestError {
     @Deprecated
     private static RequestError nonV3JSONError(String body) throws IOException {
         ObjectMapper mapper = RequestErrorObjectMapper.getInstance();
+        JsonNode error = mapper.readTree(body);
 
-        Map<String, String> errorMsg =
-                mapper.readValue(body,
-                        new TypeReference<Map<String, String>>() {
-                        });
-
+        String errorMessage = extractErrorMessage(error);
         return RequestError.newBuilder()
-                .setError(errorMsg.get("message"))
+                .setError(errorMessage)
                 .build();
+    }
+
+    private static String extractErrorMessage(JsonNode error) {
+        java.util.Optional<String> topLevelMessage = getTopLevelMessage(error);
+        java.util.Optional<String> detailMessage = getDetailMessage(error);
+        java.util.Optional<String> detailArrayMessage = getDetailArrayMessage(error);
+
+        String errorMessage;
+        if (topLevelMessage.isPresent()) {
+            errorMessage = topLevelMessage.get();
+        } else if (detailMessage.isPresent()) {
+            errorMessage = detailMessage.get();
+        } else if (detailArrayMessage.isPresent()) {
+            errorMessage = detailArrayMessage.get();
+        } else {
+            errorMessage = "Unknown response parsing error";
+        }
+
+        return errorMessage;
+    }
+
+    private static java.util.Optional<String> getTopLevelMessage(JsonNode error) {
+        JsonNode message = error.get("message");
+
+        if (message != null) {
+            return java.util.Optional.of(message.asText());
+        } else {
+            return java.util.Optional.empty();
+        }
+    }
+
+    private static java.util.Optional<String> getDetailMessage(JsonNode error) {
+        JsonNode details = error.get("details");
+        if (details != null && !details.isArray()) {
+            JsonNode message = details.get("message");
+            if (message != null) {
+                return java.util.Optional.of(message.asText());
+            }
+        }
+
+        return java.util.Optional.empty();
+    }
+
+    private static java.util.Optional<String> getDetailArrayMessage(JsonNode error) {
+        JsonNode details = error.get("details");
+        if (details != null && details.isArray()) {
+            JsonNode firstDetail = details.get(0);
+            if (firstDetail != null) {
+                JsonNode detailMessage = firstDetail.get("message");
+                if (detailMessage != null) {
+                    return java.util.Optional.of(detailMessage.asText());
+                }
+            }
+        }
+
+        return java.util.Optional.empty();
     }
 
     /**

--- a/src/test/java/com/urbanairship/api/templates/TemplateBadRequestTest.java
+++ b/src/test/java/com/urbanairship/api/templates/TemplateBadRequestTest.java
@@ -13,7 +13,7 @@ import java.io.IOException;
 
 public class TemplateBadRequestTest {
 
-    @Test
+    @Test(expected=RuntimeException.class)
     public void testErrorResponseParsing() throws IOException {
         UrbanAirshipClient client = UrbanAirshipClient.newBuilder()
                 .setKey("ISex_TTJRuarzs9-o_Gkhg")
@@ -36,6 +36,7 @@ public class TemplateBadRequestTest {
             ClientException ex = (ClientException) e.getCause().getCause();
             Assert.assertEquals(400, ex.getStatusCode());
             Assert.assertEquals("\"id\" must be a valid GUID", ex.getError().get().getError());
+            throw e;
         }
     }
 }

--- a/src/test/java/com/urbanairship/api/templates/TemplateBadRequestTest.java
+++ b/src/test/java/com/urbanairship/api/templates/TemplateBadRequestTest.java
@@ -1,0 +1,41 @@
+package com.urbanairship.api.templates;
+
+import com.urbanairship.api.client.ClientException;
+import com.urbanairship.api.client.Response;
+import com.urbanairship.api.client.UrbanAirshipClient;
+import com.urbanairship.api.push.model.notification.Notification;
+import com.urbanairship.api.templates.model.PartialPushPayload;
+import com.urbanairship.api.templates.model.TemplateResponse;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class TemplateBadRequestTest {
+
+    @Test
+    public void testErrorResponseParsing() throws IOException {
+        UrbanAirshipClient client = UrbanAirshipClient.newBuilder()
+                .setKey("ISex_TTJRuarzs9-o_Gkhg")
+                .setSecret("nDq-bQ3CT92PqCIXNtQyCQ")
+                .build();
+
+        PartialPushPayload partialPushPayload = PartialPushPayload.newBuilder()
+                .setNotification(Notification.newBuilder()
+                        .setAlert("Hello {{FIRST_NAME}} {{LAST_NAME}}, this is a test!")
+                        .build()
+                )
+                .build();
+
+        TemplateRequest request = TemplateRequest.newRequest("template-id-123")
+                .setPush(partialPushPayload);
+
+        try {
+            Response<TemplateResponse> response = client.execute(request);
+        } catch (RuntimeException e) {
+            ClientException ex = (ClientException) e.getCause().getCause();
+            Assert.assertEquals(400, ex.getStatusCode());
+            Assert.assertEquals("\"id\" must be a valid GUID", ex.getError().get().getError());
+        }
+    }
+}


### PR DESCRIPTION
Ticket: https://urbanairship.atlassian.net/browse/LIBS-2

Templates API returns a different error shape than is standard, so we
need to handle that more gracefully here. The client now returns a
useful error message when a bad request is submitted.

Also updated wiremock as I was getting strange random timeouts when
trying to run the test suite. No code changes were necessary as part of this update.