### PR TITLE
Adding missing android device payload properties

### DIFF
--- a/src/main/java/com/urbanairship/api/push/model/notification/android/AndroidDevicePayload.java
+++ b/src/main/java/com/urbanairship/api/push/model/notification/android/AndroidDevicePayload.java
@@ -30,6 +30,8 @@ public final class AndroidDevicePayload extends PushModelObject implements Devic
     private final Optional<String> summary;
     private final Optional<Style> style;
     private final Optional<String> sound;
+    private final Optional<String> icon;
+    private final Optional<String> iconColor;
     // Android L features
     private final Optional<Integer> priority;
     private final Optional<Category> category;
@@ -54,6 +56,8 @@ public final class AndroidDevicePayload extends PushModelObject implements Devic
         this.summary = Optional.fromNullable(builder.summary);
         this.style = Optional.fromNullable(builder.style);
         this.sound = Optional.fromNullable(builder.sound);
+        this.icon = Optional.fromNullable(builder.icon);
+        this.iconColor = Optional.fromNullable(builder.iconColor);
         this.priority = Optional.fromNullable(builder.priority);
         this.category = Optional.fromNullable(builder.category);
         this.visibility = Optional.fromNullable(builder.visibility);
@@ -198,6 +202,24 @@ public final class AndroidDevicePayload extends PushModelObject implements Devic
     }
 
     /**
+     * Get the icon string.
+     *
+     * @return Optional String icon
+     */
+    public Optional<String> getIcon() {
+        return icon;
+    }
+
+    /**
+     * Get the icon color string.
+     *
+     * @return Optional String icon color
+     */
+    public Optional<String> getIconColor() {
+        return iconColor;
+    }
+
+    /**
      * Get the priority specifier.
      *
      * @return Optional integer between -2 and 2.
@@ -249,6 +271,8 @@ public final class AndroidDevicePayload extends PushModelObject implements Devic
                 ", summary=" + summary +
                 ", style=" + style +
                 ", sound=" + sound +
+                ", icon=" + icon +
+                ", iconColor=" + iconColor +
                 ", priority=" + priority +
                 ", category=" + category +
                 ", visibility=" + visibility +
@@ -274,6 +298,8 @@ public final class AndroidDevicePayload extends PushModelObject implements Devic
         if (!priority.equals(that.priority)) return false;
         if (!style.equals(that.style)) return false;
         if (!sound.equals(that.sound)) return false;
+        if (!icon.equals(that.icon)) return false;
+        if (!iconColor.equals(that.iconColor)) return false;
         if (!summary.equals(that.summary)) return false;
         if (!timeToLive.equals(that.timeToLive)) return false;
         if (!title.equals(that.title)) return false;
@@ -299,6 +325,8 @@ public final class AndroidDevicePayload extends PushModelObject implements Devic
         result = 31 * result + summary.hashCode();
         result = 31 * result + style.hashCode();
         result = 31 * result + sound.hashCode();
+        result = 31 * result + icon.hashCode();
+        result = 31 * result + iconColor.hashCode();
         result = 31 * result + priority.hashCode();
         result = 31 * result + category.hashCode();
         result = 31 * result + visibility.hashCode();
@@ -321,6 +349,8 @@ public final class AndroidDevicePayload extends PushModelObject implements Devic
         private String summary = null;
         private Style style = null;
         private String sound = null;
+        private String icon = null;
+        private String iconColor = null;
         // Android L features
         private Integer priority = null;
         private Category category = null;
@@ -485,6 +515,28 @@ public final class AndroidDevicePayload extends PushModelObject implements Devic
          */
         public Builder setSound(String sound) {
             this.sound = sound;
+            return this;
+        }
+
+        /**
+         * Set the icon string.
+         *
+         * @param icon String
+         * @return Builder
+         */
+        public Builder setIcon(String icon) {
+            this.icon = icon;
+            return this;
+        }
+
+        /**
+         * Set the icon color string.
+         *
+         * @param iconColor String
+         * @return Builder
+         */
+        public Builder setIconColor(String iconColor) {
+            this.iconColor = iconColor;
             return this;
         }
 

--- a/src/main/java/com/urbanairship/api/push/model/notification/android/AndroidDevicePayload.java
+++ b/src/main/java/com/urbanairship/api/push/model/notification/android/AndroidDevicePayload.java
@@ -20,6 +20,7 @@ public final class AndroidDevicePayload extends PushModelObject implements Devic
     private final Optional<String> alert;
     private final Optional<String> collapseKey;
     private final Optional<String> notificationChannel;
+    private final Optional<String> notificationTag;
     private final Optional<PushExpiry> timeToLive;
     private final Optional<String> deliveryPriority;
     private final Optional<Boolean> delayWhileIdle;
@@ -43,6 +44,7 @@ public final class AndroidDevicePayload extends PushModelObject implements Devic
         this.alert = Optional.fromNullable(builder.alert);
         this.collapseKey = Optional.fromNullable(builder.collapseKey);
         this.notificationChannel = Optional.fromNullable(builder.notificationChannel);
+        this.notificationTag = Optional.fromNullable(builder.notificationTag);
         this.timeToLive = Optional.fromNullable(builder.timeToLive);
         this.deliveryPriority = Optional.fromNullable(builder.deliveryPriority);
         this.delayWhileIdle = Optional.fromNullable(builder.delayWhileIdle);
@@ -111,6 +113,15 @@ public final class AndroidDevicePayload extends PushModelObject implements Devic
      */
     public Optional<String> getNotificationChannel() {
         return notificationChannel;
+    }
+
+    /**
+     * Get the notification tag.
+     *
+     * @return Optional String notification tag
+     */
+    public Optional<String> getNotificationTag() {
+        return notificationTag;
     }
 
     /**
@@ -272,6 +283,7 @@ public final class AndroidDevicePayload extends PushModelObject implements Devic
                 "alert=" + alert +
                 ", collapseKey=" + collapseKey +
                 ", notificationChannel=" + notificationChannel +
+                ", notificationTag=" + notificationTag +
                 ", timeToLive=" + timeToLive +
                 ", delayWhileIdle=" + delayWhileIdle +
                 ", deliveryPriority=" + deliveryPriority +
@@ -303,6 +315,7 @@ public final class AndroidDevicePayload extends PushModelObject implements Devic
         if (!category.equals(that.category)) return false;
         if (!collapseKey.equals(that.collapseKey)) return false;
         if (!notificationChannel.equals(that.notificationChannel)) return false;
+        if (!notificationTag.equals(that.notificationTag)) return false;
         if (!delayWhileIdle.equals(that.delayWhileIdle)) return false;
         if (!deliveryPriority.equals(that.deliveryPriority)) return false;
         if (!extra.equals(that.extra)) return false;
@@ -328,6 +341,7 @@ public final class AndroidDevicePayload extends PushModelObject implements Devic
         int result = alert.hashCode();
         result = 31 * result + collapseKey.hashCode();
         result = 31 * result + notificationChannel.hashCode();
+        result = 31 * result + notificationTag.hashCode();
         result = 31 * result + timeToLive.hashCode();
         result = 31 * result + delayWhileIdle.hashCode();
         result = 31 * result + deliveryPriority.hashCode();
@@ -353,6 +367,7 @@ public final class AndroidDevicePayload extends PushModelObject implements Devic
         private String alert = null;
         private String collapseKey = null;
         private String notificationChannel = null;
+        private String notificationTag = null;
         private PushExpiry timeToLive = null;
         private Boolean delayWhileIdle = null;
         private String deliveryPriority = null;
@@ -404,6 +419,17 @@ public final class AndroidDevicePayload extends PushModelObject implements Devic
          */
         public Builder setNotificationChannel(String notificationChannel) {
             this.notificationChannel = notificationChannel;
+            return this;
+        }
+
+        /**
+         * Set the notification tag string.
+         *
+         * @param notificationTag String
+         * @return Builder
+         */
+        public Builder setNotificationTag(String notificationTag) {
+            this.notificationTag = notificationTag;
             return this;
         }
 

--- a/src/main/java/com/urbanairship/api/push/model/notification/android/AndroidDevicePayload.java
+++ b/src/main/java/com/urbanairship/api/push/model/notification/android/AndroidDevicePayload.java
@@ -19,6 +19,7 @@ public final class AndroidDevicePayload extends PushModelObject implements Devic
 
     private final Optional<String> alert;
     private final Optional<String> collapseKey;
+    private final Optional<String> notificationChannel;
     private final Optional<PushExpiry> timeToLive;
     private final Optional<String> deliveryPriority;
     private final Optional<Boolean> delayWhileIdle;
@@ -41,6 +42,7 @@ public final class AndroidDevicePayload extends PushModelObject implements Devic
     private AndroidDevicePayload(Builder builder) {
         this.alert = Optional.fromNullable(builder.alert);
         this.collapseKey = Optional.fromNullable(builder.collapseKey);
+        this.notificationChannel = Optional.fromNullable(builder.notificationChannel);
         this.timeToLive = Optional.fromNullable(builder.timeToLive);
         this.deliveryPriority = Optional.fromNullable(builder.deliveryPriority);
         this.delayWhileIdle = Optional.fromNullable(builder.delayWhileIdle);
@@ -100,6 +102,15 @@ public final class AndroidDevicePayload extends PushModelObject implements Devic
      */
     public Optional<String> getCollapseKey() {
         return collapseKey;
+    }
+
+    /**
+     * Get the notification channel.
+     *
+     * @return Optional String notification channel
+     */
+    public Optional<String> getNotificationChannel() {
+        return notificationChannel;
     }
 
     /**
@@ -260,6 +271,7 @@ public final class AndroidDevicePayload extends PushModelObject implements Devic
         return "AndroidDevicePayload{" +
                 "alert=" + alert +
                 ", collapseKey=" + collapseKey +
+                ", notificationChannel=" + notificationChannel +
                 ", timeToLive=" + timeToLive +
                 ", delayWhileIdle=" + delayWhileIdle +
                 ", deliveryPriority=" + deliveryPriority +
@@ -290,6 +302,7 @@ public final class AndroidDevicePayload extends PushModelObject implements Devic
         if (!alert.equals(that.alert)) return false;
         if (!category.equals(that.category)) return false;
         if (!collapseKey.equals(that.collapseKey)) return false;
+        if (!notificationChannel.equals(that.notificationChannel)) return false;
         if (!delayWhileIdle.equals(that.delayWhileIdle)) return false;
         if (!deliveryPriority.equals(that.deliveryPriority)) return false;
         if (!extra.equals(that.extra)) return false;
@@ -314,6 +327,7 @@ public final class AndroidDevicePayload extends PushModelObject implements Devic
     public int hashCode() {
         int result = alert.hashCode();
         result = 31 * result + collapseKey.hashCode();
+        result = 31 * result + notificationChannel.hashCode();
         result = 31 * result + timeToLive.hashCode();
         result = 31 * result + delayWhileIdle.hashCode();
         result = 31 * result + deliveryPriority.hashCode();
@@ -338,6 +352,7 @@ public final class AndroidDevicePayload extends PushModelObject implements Devic
     public static class Builder {
         private String alert = null;
         private String collapseKey = null;
+        private String notificationChannel = null;
         private PushExpiry timeToLive = null;
         private Boolean delayWhileIdle = null;
         private String deliveryPriority = null;
@@ -378,6 +393,17 @@ public final class AndroidDevicePayload extends PushModelObject implements Devic
          */
         public Builder setCollapseKey(String collapseKey) {
             this.collapseKey = collapseKey;
+            return this;
+        }
+
+        /**
+         * Set the notification channel string.
+         *
+         * @param notificationChannel String
+         * @return Builder
+         */
+        public Builder setNotificationChannel(String notificationChannel) {
+            this.notificationChannel = notificationChannel;
             return this;
         }
 

--- a/src/main/java/com/urbanairship/api/push/parse/notification/android/AndroidDevicePayloadDeserializer.java
+++ b/src/main/java/com/urbanairship/api/push/parse/notification/android/AndroidDevicePayloadDeserializer.java
@@ -36,6 +36,11 @@ public class AndroidDevicePayloadDeserializer extends JsonDeserializer<AndroidDe
                             reader.readNotificationChannel(json);
                         }
                     })
+                    .put("notification_tag", new FieldParser<AndroidDevicePayloadReader>() {
+                        public void parse(AndroidDevicePayloadReader reader, JsonParser json, DeserializationContext context) throws IOException {
+                            reader.readNotificationTag(json);
+                        }
+                    })
                     .put("time_to_live", new FieldParser<AndroidDevicePayloadReader>() {
                         public void parse(AndroidDevicePayloadReader reader, JsonParser json, DeserializationContext context) throws IOException {
                             reader.readTimeToLive(json);

--- a/src/main/java/com/urbanairship/api/push/parse/notification/android/AndroidDevicePayloadDeserializer.java
+++ b/src/main/java/com/urbanairship/api/push/parse/notification/android/AndroidDevicePayloadDeserializer.java
@@ -86,6 +86,16 @@ public class AndroidDevicePayloadDeserializer extends JsonDeserializer<AndroidDe
                             reader.readSound(json);
                         }
                     })
+                    .put("icon", new FieldParser<AndroidDevicePayloadReader>() {
+                        public void parse(AndroidDevicePayloadReader reader, JsonParser json, DeserializationContext context) throws IOException {
+                            reader.readIcon(json);
+                        }
+                    })
+                    .put("icon_color", new FieldParser<AndroidDevicePayloadReader>() {
+                        public void parse(AndroidDevicePayloadReader reader, JsonParser json, DeserializationContext context) throws IOException {
+                            reader.readIconColor(json);
+                        }
+                    })
                     .put("priority", new FieldParser<AndroidDevicePayloadReader>() {
                         public void parse(AndroidDevicePayloadReader reader, JsonParser json, DeserializationContext context) throws IOException {
                             reader.readPriority(json);

--- a/src/main/java/com/urbanairship/api/push/parse/notification/android/AndroidDevicePayloadDeserializer.java
+++ b/src/main/java/com/urbanairship/api/push/parse/notification/android/AndroidDevicePayloadDeserializer.java
@@ -31,6 +31,11 @@ public class AndroidDevicePayloadDeserializer extends JsonDeserializer<AndroidDe
                             reader.readCollapseKey(json);
                         }
                     })
+                    .put("notification_channel", new FieldParser<AndroidDevicePayloadReader>() {
+                        public void parse(AndroidDevicePayloadReader reader, JsonParser json, DeserializationContext context) throws IOException {
+                            reader.readNotificationChannel(json);
+                        }
+                    })
                     .put("time_to_live", new FieldParser<AndroidDevicePayloadReader>() {
                         public void parse(AndroidDevicePayloadReader reader, JsonParser json, DeserializationContext context) throws IOException {
                             reader.readTimeToLive(json);

--- a/src/main/java/com/urbanairship/api/push/parse/notification/android/AndroidDevicePayloadReader.java
+++ b/src/main/java/com/urbanairship/api/push/parse/notification/android/AndroidDevicePayloadReader.java
@@ -40,6 +40,10 @@ public class AndroidDevicePayloadReader implements JsonObjectReader<AndroidDevic
         builder.setNotificationChannel(StringFieldDeserializer.INSTANCE.deserialize(parser, "notification_channel"));
     }
 
+    public void readNotificationTag(JsonParser parser) throws IOException {
+        builder.setNotificationTag(StringFieldDeserializer.INSTANCE.deserialize(parser, "notification_tag"));
+    }
+
     public void readTimeToLive(JsonParser parser) throws IOException {
         builder.setTimeToLive(parser.readValueAs(PushExpiry.class));
     }

--- a/src/main/java/com/urbanairship/api/push/parse/notification/android/AndroidDevicePayloadReader.java
+++ b/src/main/java/com/urbanairship/api/push/parse/notification/android/AndroidDevicePayloadReader.java
@@ -80,6 +80,14 @@ public class AndroidDevicePayloadReader implements JsonObjectReader<AndroidDevic
         builder.setSound(parser.readValueAs(String.class));
     }
 
+    public void readIcon(JsonParser parser) throws IOException {
+        builder.setIcon(parser.readValueAs(String.class));
+    }
+
+    public void readIconColor(JsonParser parser) throws IOException {
+        builder.setIconColor(StringFieldDeserializer.INSTANCE.deserialize(parser, "icon_color"));
+    }
+
     public void readPriority(JsonParser parser) throws IOException {
         builder.setPriority(parser.readValueAs(Integer.class));
     }

--- a/src/main/java/com/urbanairship/api/push/parse/notification/android/AndroidDevicePayloadReader.java
+++ b/src/main/java/com/urbanairship/api/push/parse/notification/android/AndroidDevicePayloadReader.java
@@ -36,6 +36,10 @@ public class AndroidDevicePayloadReader implements JsonObjectReader<AndroidDevic
         builder.setCollapseKey(StringFieldDeserializer.INSTANCE.deserialize(parser, "collapse_key"));
     }
 
+    public void readNotificationChannel(JsonParser parser) throws IOException {
+        builder.setNotificationChannel(StringFieldDeserializer.INSTANCE.deserialize(parser, "notification_channel"));
+    }
+
     public void readTimeToLive(JsonParser parser) throws IOException {
         builder.setTimeToLive(parser.readValueAs(PushExpiry.class));
     }

--- a/src/main/java/com/urbanairship/api/push/parse/notification/android/AndroidDevicePayloadSerializer.java
+++ b/src/main/java/com/urbanairship/api/push/parse/notification/android/AndroidDevicePayloadSerializer.java
@@ -64,6 +64,14 @@ public class AndroidDevicePayloadSerializer extends JsonSerializer<AndroidDevice
             jgen.writeStringField("sound", payload.getSound().get());
         }
 
+        if (payload.getIcon().isPresent()) {
+            jgen.writeStringField("icon", payload.getIcon().get());
+        }
+
+        if (payload.getIconColor().isPresent()) {
+            jgen.writeStringField("icon_color", payload.getIconColor().get());
+        }
+
         if (payload.getCategory().isPresent()) {
             jgen.writeStringField("category", payload.getCategory().get().getCategory());
         }

--- a/src/main/java/com/urbanairship/api/push/parse/notification/android/AndroidDevicePayloadSerializer.java
+++ b/src/main/java/com/urbanairship/api/push/parse/notification/android/AndroidDevicePayloadSerializer.java
@@ -24,6 +24,10 @@ public class AndroidDevicePayloadSerializer extends JsonSerializer<AndroidDevice
             jgen.writeStringField("collapse_key", payload.getCollapseKey().get());
         }
 
+        if (payload.getNotificationChannel().isPresent()) {
+            jgen.writeStringField("notification_channel", payload.getNotificationChannel().get());
+        }
+
         if (payload.getTimeToLive().isPresent()) {
             jgen.writeObjectField("time_to_live", payload.getTimeToLive().get());
         }

--- a/src/main/java/com/urbanairship/api/push/parse/notification/android/AndroidDevicePayloadSerializer.java
+++ b/src/main/java/com/urbanairship/api/push/parse/notification/android/AndroidDevicePayloadSerializer.java
@@ -28,6 +28,10 @@ public class AndroidDevicePayloadSerializer extends JsonSerializer<AndroidDevice
             jgen.writeStringField("notification_channel", payload.getNotificationChannel().get());
         }
 
+        if (payload.getNotificationTag().isPresent()) {
+            jgen.writeStringField("notification_tag", payload.getNotificationTag().get());
+        }
+
         if (payload.getTimeToLive().isPresent()) {
             jgen.writeObjectField("time_to_live", payload.getTimeToLive().get());
         }

--- a/src/test/java/com/urbanairship/api/push/parse/notification/android/PayloadDeserializerTest.java
+++ b/src/test/java/com/urbanairship/api/push/parse/notification/android/PayloadDeserializerTest.java
@@ -68,6 +68,27 @@ public class PayloadDeserializerTest {
     }
 
     @Test
+    public void testNotificationChannel() throws Exception {
+        String json
+                = "{"
+                + "  \"notification_channel\": \"channel1\""
+                + "}";
+
+        AndroidDevicePayload expected = AndroidDevicePayload.newBuilder()
+                .setNotificationChannel("channel1")
+                .build();
+
+        AndroidDevicePayload payload = mapper.readValue(json, AndroidDevicePayload.class);
+        assertNotNull(payload);
+        assertNotNull(payload.getNotificationChannel());
+        assertFalse(payload.getAlert().isPresent());
+        assertFalse(payload.getExtra().isPresent());
+        assertTrue(payload.getNotificationChannel().isPresent());
+        assertEquals("channel1", payload.getNotificationChannel().get());
+        assertEquals(expected, payload);
+    }
+
+    @Test
     public void testTimeToLive() throws Exception {
         String json
                 = "{"

--- a/src/test/java/com/urbanairship/api/push/parse/notification/android/PayloadDeserializerTest.java
+++ b/src/test/java/com/urbanairship/api/push/parse/notification/android/PayloadDeserializerTest.java
@@ -83,8 +83,31 @@ public class PayloadDeserializerTest {
         assertNotNull(payload.getNotificationChannel());
         assertFalse(payload.getAlert().isPresent());
         assertFalse(payload.getExtra().isPresent());
+        assertFalse(payload.getNotificationTag().isPresent());
         assertTrue(payload.getNotificationChannel().isPresent());
         assertEquals("channel1", payload.getNotificationChannel().get());
+        assertEquals(expected, payload);
+    }
+
+    @Test
+    public void testNotificationTag() throws Exception {
+        String json
+                = "{"
+                + "  \"notification_tag\": \"nt1\""
+                + "}";
+
+        AndroidDevicePayload expected = AndroidDevicePayload.newBuilder()
+                .setNotificationTag("nt1")
+                .build();
+
+        AndroidDevicePayload payload = mapper.readValue(json, AndroidDevicePayload.class);
+        assertNotNull(payload);
+        assertNotNull(payload.getNotificationTag());
+        assertFalse(payload.getAlert().isPresent());
+        assertFalse(payload.getExtra().isPresent());
+        assertFalse(payload.getNotificationChannel().isPresent());
+        assertTrue(payload.getNotificationTag().isPresent());
+        assertEquals("nt1", payload.getNotificationTag().get());
         assertEquals(expected, payload);
     }
 

--- a/src/test/java/com/urbanairship/api/push/parse/notification/android/PayloadDeserializerTest.java
+++ b/src/test/java/com/urbanairship/api/push/parse/notification/android/PayloadDeserializerTest.java
@@ -338,6 +338,30 @@ public class PayloadDeserializerTest {
     }
 
     @Test
+    public void testIcon() throws Exception {
+        String json =
+                "{" +
+                        "\"icon\": \"icon.xml\"" +
+                 "}";
+
+        AndroidDevicePayload payload = mapper.readValue(json, AndroidDevicePayload.class);
+        assertNotNull(payload);
+        assertEquals(payload.getIcon().get(), "icon.xml");
+    }
+
+    @Test
+    public void testIconColor() throws Exception {
+        String json =
+                "{" +
+                        "\"icon_color\": \"#012345\"" +
+                 "}";
+
+        AndroidDevicePayload payload = mapper.readValue(json, AndroidDevicePayload.class);
+        assertNotNull(payload);
+        assertEquals(payload.getIconColor().get(), "#012345");
+    }
+
+    @Test
     public void testPriority() throws Exception {
         String json =
                 "{" +

--- a/src/test/java/com/urbanairship/api/push/parse/notification/android/PayloadSerializerTest.java
+++ b/src/test/java/com/urbanairship/api/push/parse/notification/android/PayloadSerializerTest.java
@@ -68,6 +68,7 @@ public class PayloadSerializerTest {
                 .setCategory(Category.ALARM)
                 .setCollapseKey("blah")
                 .setNotificationChannel("channel1")
+                .setNotificationTag("nt1")
                 .setDelayWhileIdle(true)
                 .setDeliveryPriority("high")
                 .setInteractive(interactive)
@@ -89,6 +90,7 @@ public class PayloadSerializerTest {
                 "\"alert\":\"Hi\"," +
                 "\"collapse_key\":\"blah\"," +
                 "\"notification_channel\":\"channel1\"," +
+                "\"notification_tag\":\"nt1\"," +
                 "\"time_to_live\":12345," +
                 "\"delivery_priority\":\"high\"," +
                 "\"delay_while_idle\":true," +

--- a/src/test/java/com/urbanairship/api/push/parse/notification/android/PayloadSerializerTest.java
+++ b/src/test/java/com/urbanairship/api/push/parse/notification/android/PayloadSerializerTest.java
@@ -74,6 +74,8 @@ public class PayloadSerializerTest {
                 .setPriority(1)
                 .setPublicNotification(publicNotification)
                 .setSound("cowbell.mp3")
+                .setIcon("icon.xml")
+                .setIconColor("#012345")
                 .setStyle(bigTextStyle)
                 .setSummary("A summary")
                 .setTimeToLive(expiry)
@@ -127,6 +129,8 @@ public class PayloadSerializerTest {
                 "}," +
                 "\"summary\":\"A summary\"," +
                 "\"sound\":\"cowbell.mp3\"," +
+                "\"icon\":\"icon.xml\"," +
+                "\"icon_color\":\"#012345\"," +
                 "\"category\":\"alarm\"," +
                 "\"priority\":1," +
                 "\"style\":{" +

--- a/src/test/java/com/urbanairship/api/push/parse/notification/android/PayloadSerializerTest.java
+++ b/src/test/java/com/urbanairship/api/push/parse/notification/android/PayloadSerializerTest.java
@@ -67,6 +67,7 @@ public class PayloadSerializerTest {
                 .setAlert("Hi")
                 .setCategory(Category.ALARM)
                 .setCollapseKey("blah")
+                .setNotificationChannel("channel1")
                 .setDelayWhileIdle(true)
                 .setDeliveryPriority("high")
                 .setInteractive(interactive)
@@ -87,6 +88,7 @@ public class PayloadSerializerTest {
         String json = "{" +
                 "\"alert\":\"Hi\"," +
                 "\"collapse_key\":\"blah\"," +
+                "\"notification_channel\":\"channel1\"," +
                 "\"time_to_live\":12345," +
                 "\"delivery_priority\":\"high\"," +
                 "\"delay_while_idle\":true," +


### PR DESCRIPTION
### What does this do and why?
This adds some missing properties from android device payload.

### Additional notes for reviewers
The added properties in the android device payload are:
- icon
- icon_color 
- notification_channel
- notification_tag

(https://docs.airship.com/api/ua/#schemas/androidoverrideobject)

### Testing
- [ ] If these changes added new functionality, I tested them against the live API with real auth
- [x] I wrote tests covering these changes  
- [x] I ran the full test suite and it passed

### Urban Airship Contribution Agreement
- [x] I've filled out and signed UA's contribution agreement form.