### PR TITLE
Handle Jackson artifact versions via Jackson BOM and update jackson-databind

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,18 @@
         </plugins>
     </build>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>2.9.9.20190807</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <!-- Third party dependencies -->
     <dependencies>
 
@@ -167,7 +179,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.9.2</version>
         </dependency>
 
         <dependency>
@@ -179,13 +190,11 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.9.9</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-joda</artifactId>
-            <version>2.9.9</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
### What does this do and why?
Use Jackson BOM (`jackson-bom`) to manage Jackson artifact versions. Also updates to the latest version, which fixes an NPE bug in `jackson-databind` (2.9.9.2 -> 2.9.9.3). https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9#micro-patches

### Testing
- [ ] If these changes added new functionality, I tested them against the live API with real auth
- [ ] I wrote tests covering these changes  
- [x] I ran the full test suite and it passed

### Test run results, including date and time:

### Urban Airship Contribution Agreement
[Link here](https://docs.google.com/forms/d/e/1FAIpQLScErfiz-fXSPpVZ9r8Di2Tr2xDFxt5MgzUel0__9vqUgvko7Q/viewform)

- [x] I've filled out and signed UA's contribution agreement form.