### PR TITLE
Update to Maven Javadoc Plugin 3.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9.1</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>


### PR DESCRIPTION
### What does this do and why?
Updates Maven Javadoc Plugin from 2.9.1 to 3.1.1.

Changes:
* 2.10: https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12317529&version=12330871
* 2.10.1: https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12317529&version=12330872
* 2.10.2: https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12317529&version=12330873
* 2.10.3: https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12317529&version=12330876
* 2.10.4: https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12317529&version=12331967
* 3.0.0: https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12317529&version=12330875
* 3.0.1: https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12317529&version=12342283
* 3.1.0: https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12317529&version=12343313
* 3.1.1: https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12317529&version=12345060

### Testing
- [ ] If these changes added new functionality, I tested them against the live API with real auth
- [ ] I wrote tests covering these changes  
- [x] I ran the full test suite and it passed

### Urban Airship Contribution Agreement
[Link here](https://docs.google.com/forms/d/e/1FAIpQLScErfiz-fXSPpVZ9r8Di2Tr2xDFxt5MgzUel0__9vqUgvko7Q/viewform)

- [x] I've filled out and signed UA's contribution agreement form.