### PR TITLE
Update to JaCoCo Maven Plugin 0.8.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.0</version>
+                <version>0.8.4</version>
                 <executions>
                     <execution>
                         <id>prepare-agent</id>


### PR DESCRIPTION
### What does this do and why?
Updates the JaCoCo Maven Plugin from 0.8.0 to 0.8.4.

Changes:
* 0.8.1: https://github.com/jacoco/jacoco/releases/tag/v0.8.1
* 0.8.2: https://github.com/jacoco/jacoco/releases/tag/v0.8.2
* 0.8.3: https://github.com/jacoco/jacoco/releases/tag/v0.8.3
* 0.8.4: https://github.com/jacoco/jacoco/releases/tag/v0.8.4

### Testing
- [ ] If these changes added new functionality, I tested them against the live API with real auth
- [ ] I wrote tests covering these changes  
- [x] I ran the full test suite and it passed

### Urban Airship Contribution Agreement
[Link here](https://docs.google.com/forms/d/e/1FAIpQLScErfiz-fXSPpVZ9r8Di2Tr2xDFxt5MgzUel0__9vqUgvko7Q/viewform)

- [x] I've filled out and signed UA's contribution agreement form.