### PR TITLE
Update to async-http-client 2.10.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -227,7 +227,7 @@
         <dependency>
             <groupId>org.asynchttpclient</groupId>
             <artifactId>async-http-client</artifactId>
-            <version>2.4.8</version>
+            <version>2.10.4</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
### What does this do and why?

Update async-http-client to the latest version. Version 2.4.8 was released over a year ago.

### Testing
- [x] If these changes added new functionality, I tested them against the live API with real auth
- [x] I ran the full test suite and it passed

### Test run results, including date and time:

### Urban Airship Contribution Agreement
[Link here](https://docs.google.com/forms/d/e/1FAIpQLScErfiz-fXSPpVZ9r8Di2Tr2xDFxt5MgzUel0__9vqUgvko7Q/viewform)

- [x] I've filled out and signed UA's contribution agreement form.
