### PR TITLE
Use Jackson BOM to manage Jackson artifact versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,18 @@
         </plugins>
     </build>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>2.10.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <!-- Third party dependencies -->
     <dependencies>
 
@@ -173,7 +185,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.10.0</version>
         </dependency>
 
         <dependency>
@@ -185,13 +196,11 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.10.0</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-joda</artifactId>
-            <version>2.9.10</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
### What does this do and why?

Start using the [Jackson BOM](https://github.com/FasterXML/jackson-bom) (Bill of Materials) to manage all Jackson artifacts. Before this change `jackson-datatype-joda` was on 2.9.10, while the other Jackson dependencies were already on 2.10.0. Ideally they should all be in sync, and Jackson BOM makes this easy.

### Testing
- [x] I ran the full test suite and it passed

### Urban Airship Contribution Agreement
[Link here](https://docs.google.com/forms/d/e/1FAIpQLScErfiz-fXSPpVZ9r8Di2Tr2xDFxt5MgzUel0__9vqUgvko7Q/viewform)

- [x] I've filled out and signed UA's contribution agreement form.