### PR TITLE
Improve custom event capabilities

### DIFF
--- a/src/main/java/com/urbanairship/api/common/parse/MapOfObjectsDeserializer.java
+++ b/src/main/java/com/urbanairship/api/common/parse/MapOfObjectsDeserializer.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2013-2016.  Urban Airship and Contributors
+ */
+
+package com.urbanairship.api.common.parse;
+
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import java.io.IOException;
+import java.util.Map;
+
+
+
+public class MapOfObjectsDeserializer {
+
+    public static final MapOfObjectsDeserializer INSTANCE = new MapOfObjectsDeserializer();
+
+    private MapOfObjectsDeserializer() { }
+
+    public Map<String, Object> deserialize(JsonParser parser, String fieldName) throws APIParsingException {
+        try {
+            return parser.readValueAs(new TypeReference<Map<String, Object>>() {});
+        }
+        catch (IOException e) {
+            APIParsingException.raise(String.format("%s was not valid", fieldName), parser);
+        }
+        // Satisfy the java compiler - it can't figure out that
+        // APIParsingException.raise() always throws.
+        return null;
+    }
+}

--- a/src/main/java/com/urbanairship/api/customevents/model/CustomEventBody.java
+++ b/src/main/java/com/urbanairship/api/customevents/model/CustomEventBody.java
@@ -14,7 +14,7 @@ public class CustomEventBody {
     private final Optional<String> transaction;
     private final Optional<String> interactionId;
     private final Optional<String> interactionType;
-    private final Optional<ImmutableMap<String, String>> properties;
+    private final Optional<ImmutableMap<String, Object>> properties;
     private final String sessionId;
 
     private CustomEventBody(Builder builder) {
@@ -105,7 +105,7 @@ public class CustomEventBody {
      *
      * @return Optional ImmutableMap of Strings
      */
-    public Optional<ImmutableMap<String, String>> getProperties() {
+    public Optional<ImmutableMap<String, Object>> getProperties() {
         return properties;
     }
 
@@ -155,7 +155,7 @@ public class CustomEventBody {
         private String transaction = null;
         private String interactionId = null;
         private String interactionType = null;
-        private ImmutableMap.Builder<String, String> properties = ImmutableMap.builder();
+        private ImmutableMap.Builder<String, Object> properties = ImmutableMap.builder();
         private String sessionId = null;
 
         private Builder() {
@@ -234,10 +234,10 @@ public class CustomEventBody {
          * Maximum 255 character string length.
          *
          * @param key String
-         * @param value String
+         * @param value Object
          * @return CustomEventBody Builder
          */
-        public Builder addPropertiesEntry(String key, String value) {
+        public Builder addPropertiesEntry(String key, Object value) {
             this.properties.put(key, value);
             return this;
         }
@@ -247,10 +247,10 @@ public class CustomEventBody {
          * custom properties. Events are limited to 100 properties.
          * Maximum 255 character string length.
          *
-         * @param entries A Map of Strings
+         * @param entries A Map of Objects
          * @return CustomEventBody Builder
          */
-        public Builder addAllPropertyEntries(Map<String, String> entries) {
+        public Builder addAllPropertyEntries(Map<String, Object> entries) {
             this.properties.putAll(entries);
             return this;
         }

--- a/src/main/java/com/urbanairship/api/customevents/model/CustomEventBody.java
+++ b/src/main/java/com/urbanairship/api/customevents/model/CustomEventBody.java
@@ -257,7 +257,7 @@ public class CustomEventBody {
 
         /**
          * Set the sessionID. The user session during which the event occurred.
-         * You must supply and maintain session identifiers.
+         * You must maintain session identifiers.
          *
          * @param sessionId String
          * @return CustomEventBody Builder
@@ -269,7 +269,6 @@ public class CustomEventBody {
 
         public CustomEventBody build() {
             Preconditions.checkNotNull(name, "'name' must be set");
-            Preconditions.checkNotNull(sessionId, "'sessionId' must be set");
 
             return new CustomEventBody(this);
         }

--- a/src/main/java/com/urbanairship/api/customevents/model/CustomEventChannelType.java
+++ b/src/main/java/com/urbanairship/api/customevents/model/CustomEventChannelType.java
@@ -5,7 +5,9 @@ import com.google.common.base.Optional;
 public enum CustomEventChannelType {
     IOS_CHANNEL("ios_channel"),
     ANDROID_CHANNEL("android_channel"),
-    AMAZON_CHANNEL("amazon_channel");
+    AMAZON_CHANNEL("amazon_channel"),
+    WEB_CHANNEL("web_channel"),
+    GENERIC_CHANNEL("channel");
 
     private final String identifier;
 

--- a/src/main/java/com/urbanairship/api/customevents/parse/CustomEventBodyReader.java
+++ b/src/main/java/com/urbanairship/api/customevents/parse/CustomEventBodyReader.java
@@ -3,7 +3,7 @@ package com.urbanairship.api.customevents.parse;
 import com.fasterxml.jackson.core.JsonParser;
 import com.urbanairship.api.common.parse.APIParsingException;
 import com.urbanairship.api.common.parse.JsonObjectReader;
-import com.urbanairship.api.common.parse.MapOfStringsDeserializer;
+import com.urbanairship.api.common.parse.MapOfObjectsDeserializer;
 import com.urbanairship.api.common.parse.StringFieldDeserializer;
 import com.urbanairship.api.customevents.model.CustomEventBody;
 
@@ -37,7 +37,7 @@ public class CustomEventBodyReader implements JsonObjectReader<CustomEventBody> 
     }
 
     public void readProperties(JsonParser parser) throws IOException {
-        builder.addAllPropertyEntries(MapOfStringsDeserializer.INSTANCE.deserialize(parser, "properties"));
+        builder.addAllPropertyEntries(MapOfObjectsDeserializer.INSTANCE.deserialize(parser, "properties"));
     }
 
     public void readSessionId(JsonParser parser) throws IOException {

--- a/src/main/java/com/urbanairship/api/customevents/parse/CustomEventUserDeserializer.java
+++ b/src/main/java/com/urbanairship/api/customevents/parse/CustomEventUserDeserializer.java
@@ -33,6 +33,18 @@ public class CustomEventUserDeserializer {
                     reader.readChannel(CustomEventChannelType.IOS_CHANNEL, json);
                 }
             })
+            .put("web_channel", new FieldParser<CustomEventUserReader>() {
+                @Override
+                public void parse(CustomEventUserReader reader, JsonParser json, DeserializationContext context) throws IOException {
+                    reader.readChannel(CustomEventChannelType.WEB_CHANNEL, json);
+                }
+            })
+            .put("channel", new FieldParser<CustomEventUserReader>() {
+                @Override
+                public void parse(CustomEventUserReader reader, JsonParser json, DeserializationContext context) throws IOException {
+                    reader.readChannel(CustomEventChannelType.GENERIC_CHANNEL, json);
+                }
+            })
             .build()
     );
 }

--- a/src/test/java/com/urbanairship/api/customevents/CustomEventRequestTest.java
+++ b/src/test/java/com/urbanairship/api/customevents/CustomEventRequestTest.java
@@ -32,12 +32,12 @@ public class CustomEventRequestTest {
             .setSessionId("sessionId")
             .build();
 
-    DateTime occured = new DateTime(2015, 5, 2, 2, 31, 22, DateTimeZone.UTC);
+    DateTime occurred = new DateTime(2015, 5, 2, 2, 31, 22, DateTimeZone.UTC);
 
     CustomEventPayload customEventPayload = CustomEventPayload.newBuilder()
             .setCustomEventBody(customEventBody)
             .setCustomEventUser(customEventUser)
-            .setOccurred(occured)
+            .setOccurred(occurred)
             .build();
 
     CustomEventRequest customEventRequest = CustomEventRequest.newRequest(customEventPayload);
@@ -70,8 +70,8 @@ public class CustomEventRequestTest {
     public void testURI() throws Exception {
         URI baseURI = URI.create("https://go.urbanairship.com");
 
-        URI expextedURI = URI.create("https://go.urbanairship.com/api/custom-events/");
-        assertEquals(customEventRequest.getUri(baseURI), expextedURI);
+        URI expectedURI = URI.create("https://go.urbanairship.com/api/custom-events/");
+        assertEquals(customEventRequest.getUri(baseURI), expectedURI);
     }
 
     @Test

--- a/src/test/java/com/urbanairship/api/customevents/model/CustomEventPayloadTest.java
+++ b/src/test/java/com/urbanairship/api/customevents/model/CustomEventPayloadTest.java
@@ -20,7 +20,7 @@ public class CustomEventPayloadTest {
                 .setChannel("e393d28e-23b2-4a22-9ace-dc539a5b07a8")
                 .build();
 
-        Map<String, String> properties = new HashMap<String, String>();
+        Map<String, Object> properties = new HashMap<String, Object>();
         properties.put("category", "mens shoes");
         properties.put("id", "pid-11046546");
         properties.put("description", "sky high");

--- a/src/test/java/com/urbanairship/api/customevents/parse/CustomEventUserSerializerTest.java
+++ b/src/test/java/com/urbanairship/api/customevents/parse/CustomEventUserSerializerTest.java
@@ -30,6 +30,16 @@ public class CustomEventUserSerializerTest {
                 .setChannel("amazonChannel")
                 .build();
 
+        CustomEventUser webUser = CustomEventUser.newBuilder()
+                .setCustomEventChannelType(CustomEventChannelType.WEB_CHANNEL)
+                .setChannel("webChannel")
+                .build();
+
+        CustomEventUser genericUser = CustomEventUser.newBuilder()
+                .setCustomEventChannelType(CustomEventChannelType.GENERIC_CHANNEL)
+                .setChannel("genericChannel")
+                .build();
+
         String iosJson = MAPPER.writeValueAsString(iosUser);
         String iosExpected = "{\"ios_channel\":\"iOSChannel\"}";
         assertEquals(iosJson, iosExpected);
@@ -41,5 +51,13 @@ public class CustomEventUserSerializerTest {
         String amazonJson = MAPPER.writeValueAsString(amazonUser);
         String amazonExpected = "{\"amazon_channel\":\"amazonChannel\"}";
         assertEquals(amazonJson, amazonExpected);
+
+        String webJson = MAPPER.writeValueAsString(webUser);
+        String webExpected = "{\"web_channel\":\"webChannel\"}";
+        assertEquals(webJson, webExpected);
+
+        String genericJson = MAPPER.writeValueAsString(genericUser);
+        String genericExpected = "{\"channel\":\"genericChannel\"}";
+        assertEquals(genericJson, genericExpected);
     }
 }


### PR DESCRIPTION
### What does this do and why?
The client does not yet support all features of the [Custom Event API reference](https://docs.airship.com/api/ua/#schemas%2fcustomeventobject):
 * Event properties only support simple string key-value-pairs instead of complex objects
 * No generic channel or web channel can be addressed
 * Session ID is required although it is not named as required in the API reference

The changes will add support for the missing aspects and will delete the validation of the optional session ID.

### Additional notes for reviewers
* Modifications are in use in a backend integration of Immowelt AG
* Contact person for Airship support is aiden.hickmann@airship.com

### Testing
- [x] If these changes added new functionality, I tested them against the live API with real auth
- [x] I wrote tests covering these changes  
- [x] I ran the full test suite and it passed

### Test run results, including date and time:
see attachment:
[test-results.txt](https://github.com/urbanairship/java-library/files/4730938/test-results.txt)


### Airship Contribution Agreement
[Link here](https://docs.google.com/forms/d/e/1FAIpQLScErfiz-fXSPpVZ9r8Di2Tr2xDFxt5MgzUel0__9vqUgvko7Q/viewform)

- [x] I've filled out and signed Airship's contribution agreement form.


