### PR TITLE
[MNT] Remove release/deployment section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,19 +12,6 @@ General documentation can be found here: http://docs.airship.com/
 Java client library documentation can be found here: https://docs.airship.com/api/libraries/java/
 
 
-Workflows / Deployment
-======================
-
-CI runs automatically on every pull request (`maven-tests` workflow, Java 11).
-
-### Publishing a release
-
-1. Ensure master is in sync with `java-library` (public repo) and the version in `pom.xml` is correct.
-2. Trigger the [Sonatype Release workflow](https://github.com/urbanairship/java-library-dev/actions/workflows/sonatype-release.yaml) manually via **Run workflow → master**.
-3. Once the workflow completes, open the **Summary** tab of the workflow run — it prints the direct link to approve and publish the staged bundle on [Sonatype Central](https://central.sonatype.com/publishing).
-4. Approve the bundle on Sonatype. The public `java-library` repo is synced automatically by the workflow (master + tag).
-
-
 Installation
 ====================
 


### PR DESCRIPTION
## Summary

- Remove the **Workflows / Deployment** section from `README.md`.

## Why

This section documented the internal release process — the private `java-library-dev` mirror, the Sonatype approval flow, and the automated sync mechanics. That information does not belong in the public repository. Release documentation is maintained privately in `java-library-dev` (`.github/workflows/README.md`).

Paired with urbanairship/java-library-dev#378, which removes the same section from the source README so future syncs stay clean.

## Test plan

- [ ] Review rendered README — Documentation section flows directly into Installation, no internal release docs